### PR TITLE
Fix dynamic route add

### DIFF
--- a/backbone.subroute.js
+++ b/backbone.subroute.js
@@ -20,7 +20,8 @@
         constructor: function(prefix, options) {
 
             // each subroute instance should have its own routes hash
-            this.routes = _.clone(this.routes);
+            // if not route set then create a object 
+            this.routes = _.clone(this.routes) || {};
 
             // Prefix is optional, set to empty string if not passed
             this.prefix = prefix = prefix || "";


### PR DESCRIPTION
when a user doesn't create routes and he wanna add dynamic route subroute throw error because the varibale routes is undifined 
example : 
var browserModule = new Backbone.SubRoute("browser",{createTrailingSlashRoutes: true});
browserModule.route('browse',function(){console.log('browse');})
