### PR TITLE
Enable possibility to pass an empty prefix

### DIFF
--- a/backbone.subroute.js
+++ b/backbone.subroute.js
@@ -79,8 +79,12 @@
             }
 
             var _route = this.prefix;
-            if (route && route.length > 0)
-                _route += (this.separator + route);
+            if (route && route.length > 0) {
+                if (this.prefix.length > 0)
+                    _route += this.separator;
+
+                _route += route;
+            }
 
             if (this.createTrailingSlashRoutes) {
                 this.routes[_route + '/'] = name;

--- a/spec/index.html
+++ b/spec/index.html
@@ -29,6 +29,7 @@
     <script type="text/javascript" src="js/prefix-has-trailing-slash-specs.js"></script>
     <script type="text/javascript" src="js/prefix-and-route-both-have-trailing-slashes-specs.js"></script>
     <script type="text/javascript" src="js/load-url-on-init-specs.js"></script>
+    <script type="text/javascript" src="js/no-separator-on-empty-prefix-specs.js"></script>
 
     <script type="text/javascript">
         (function () {

--- a/spec/js/no-separator-on-empty-prefix-specs.js
+++ b/spec/js/no-separator-on-empty-prefix-specs.js
@@ -1,0 +1,43 @@
+describe("When using an empty prefix", function() {
+
+    beforeEach(function() {
+        SubRouteTest.setUp.call(this, "", {}, {
+            "": "handleDefaultRoute",
+            "about": "handleAboutRoute"
+        });
+    });
+
+    afterEach(function() {
+        SubRouteTest.tearDown.call(this);
+    });
+
+    it('has a "default" route', function() {
+        expect(this.router.routes[""]).toEqual('handleDefaultRoute');
+    });
+
+    it('has a "about" route', function() {
+        expect(this.router.routes.about).toEqual('handleAboutRoute');
+    });
+
+    it('has not a "about" route with a separator', function() {
+        expect(this.router.routes["/about"]).toBeUndefined();
+    });
+
+    it('triggers the "default" route', function() {
+        this.router.bind("route:handleDefaultRoute", this.routeSpy);
+        this.baseRouter.navigate("", {
+            trigger: true
+        });
+        expect(this.routeSpy).toHaveBeenCalledOnce();
+        expect(this.routeSpy).toHaveBeenCalledWith();
+    });
+
+    it('triggers the "about" route', function() {
+        this.router.bind("route:handleAboutRoute", this.routeSpy);
+        this.baseRouter.navigate("about", {
+            trigger: true
+        });
+        expect(this.routeSpy).toHaveBeenCalledOnce();
+        expect(this.routeSpy).toHaveBeenCalledWith();
+    });
+});

--- a/spec/js/spec-helper.js
+++ b/spec/js/spec-helper.js
@@ -37,7 +37,7 @@ SubRouteTest.setUp = function(prefix, options, overrideRoutes) {
         routesToUse = overrideRoutes;
     }
 
-    if (prefix) {
+    if (prefix !== undefined) {
         var testRouter = Backbone.SubRoute.extend({
             routes: routesToUse
         });


### PR DESCRIPTION
This feature could be used to create a main router that delegates unmatched paths to a "global" router. The main router would then only contains sub router definitions. I put an example usage at the bottom.

Tell me if it's something you would accept. Maybe there is already a better idea to achieve this. Sorry in advance for any missing things, first time I contribute to a JavaScript project :)

Example Usage:

``` javascript
var Router = Backbone.Router.extend({
    routes: {
      // Sub paths
      "projects/*subroute" : "routeProjects",

      // Fallback to MainRouter
      "*subroute" : "routeMain",
    },

    routeMain : function (subroute) {
        if (!App.Routers.Main) {
          App.Routers.Main = new MainRouter("");
        }
    },

    routeProjects : function (subroute) {
        if (!App.Routers.Projects) {
          App.Routers.Projects = new ProjectsRouter("projects");
        }
    }
  });
```

Regards,
Matt
