### PR TITLE
actually export the router when used as CommonJS module

### DIFF
--- a/backbone.subroute.js
+++ b/backbone.subroute.js
@@ -12,7 +12,7 @@
         define(['underscore', 'backbone'], factory);
     } else if (typeof exports === 'object') {
         // Next for Node.js, CommonJS, browserify...
-        factory(require('underscore'), require('backbone'));
+        module.exports = factory(require('underscore'), require('backbone'));
     } else {
         // Browser globals for the unenlightened...
         factory(_, Backbone);


### PR DESCRIPTION
When using backbone.subroute with browserify requiring it returns an empty object. I guess I could just use the export of the backbone module after requiring backbone.subroute but that is a bit ugly.

I want

```
var SubRouter = require('backbone.subroute');
var foo = SubRouter.extend({
   ...
```
